### PR TITLE
feature(laravel-test): upgrade to php 7.2 with xdebug 2.6.0

### DIFF
--- a/laravel-test/Dockerfile
+++ b/laravel-test/Dockerfile
@@ -1,13 +1,14 @@
 # Use the multi-stage feature to import Composer securely
 FROM composer:1.6
 # Use PHP as primary language
-FROM php:7.1-cli
+FROM php:7.2
 
 # Update, upgrade and install some dependencies
 RUN apt-get update \
 	&& apt-get upgrade -y \
 	&& apt-get install -y \
 		git \
+		gnupg \
 		libpng-dev \
 		libsqlite3-dev \
 		unzip \

--- a/laravel-test/README.md
+++ b/laravel-test/README.md
@@ -5,7 +5,7 @@ This is mostly used for running [_CI_ testing](https://docs.peakfijn.nl/docker/p
 
 ## Features
 
-- Runs **PHP 7.1** using `php:7.1-cli`
+- Runs **PHP 7.2** using `php:7.2`
 - Imports **Composer 1.6** using `composer:1.6`
 - Installs **Node 8 LTS** using `https://deb.nodesource.com/setup_8.x`
 - Supports **SQLite 3** using `apt-get install libsqlite3-dev`


### PR DESCRIPTION
This upgrades the Laravel Test image to the latest PHP (7.2) with the latest xDebug (2.6.0). The latter was just released.