### PR TITLE
feature(commitlint): add preinstalled commitlint image

### DIFF
--- a/images/commitlint/Dockerfile
+++ b/images/commitlint/Dockerfile
@@ -1,0 +1,9 @@
+FROM bycedric/ci-node
+
+LABEL maintainer 'Cedric van Putten <cedric@peakfijn.nl>'
+
+RUN apk add --no-cache git \
+	&& npm install -g \
+		@peakfijn/config-commitlint \
+		commitlint \
+	&& npm cache rm --force

--- a/images/commitlint/README.md
+++ b/images/commitlint/README.md
@@ -1,0 +1,9 @@
+# Commitlint - Peakfijn
+
+A simple Node image based on Alpine Linux, preinstalled with Commitlint and Peakfijn Conventions.
+
+## Performance tweaks
+
+- All dependencies are installed and updated within a single `RUN` statement to avoid intermediate containers.
+- `npm` cache is removed or turned off to avoid large build images.
+- See [`ci-node`](https://github.com/byCedric/Docker/tree/master/images/ci-node) for all other tweaks.


### PR DESCRIPTION
This allows us to "just pull" an image in our CI and start validating the commits straight away. It's an easy way to avoid "The Big NPM Install"(TM) and, with that, increasing speed drastically.