### PR TITLE
refactor: use official node lts alpine images

### DIFF
--- a/images/commitlint/Dockerfile
+++ b/images/commitlint/Dockerfile
@@ -1,4 +1,4 @@
-FROM bycedric/ci-node
+FROM node:10-alpine
 
 LABEL maintainer 'Cedric van Putten <cedric@peakfijn.nl>'
 

--- a/images/release-expo/Dockerfile
+++ b/images/release-expo/Dockerfile
@@ -1,4 +1,4 @@
-FROM bycedric/ci-node
+FROM node:10-alpine
 
 LABEL maintainer 'Cedric van Putten <cedric@peakfijn.nl>'
 

--- a/images/release-laravel/Dockerfile
+++ b/images/release-laravel/Dockerfile
@@ -1,4 +1,4 @@
-FROM bycedric/ci-node
+FROM node:10-alpine
 
 LABEL maintainer 'Cedric van Putten <cedric@peakfijn.nl>'
 

--- a/images/release-react/Dockerfile
+++ b/images/release-react/Dockerfile
@@ -1,4 +1,4 @@
-FROM bycedric/ci-node
+FROM node:10-alpine
 
 LABEL maintainer 'Cedric van Putten <cedric@peakfijn.nl>'
 


### PR DESCRIPTION
### Linked issue
It's a bit more secure and stable.
